### PR TITLE
Fix raycasts going through UI

### DIFF
--- a/Assets/Scenes/LevelGenerationScene.unity
+++ b/Assets/Scenes/LevelGenerationScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4465788, g: 0.49641603, b: 0.57481974, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657832, g: 0.49641538, b: 0.5748186, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -790,8 +790,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
-    m_Left: 0
-    m_Right: 0
+    m_Left: 10
+    m_Right: 10
     m_Top: 1
     m_Bottom: 0
   m_ChildAlignment: 0
@@ -868,7 +868,7 @@ MonoBehaviour:
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_Font: {fileID: 12800000, guid: 747cfffe008777f46ba1fddd5bab6119, type: 3}
     m_FontSize: 18
     m_FontStyle: 0
     m_BestFit: 0
@@ -1061,7 +1061,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 254883060}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -2}
+  m_LocalPosition: {x: 0, y: 0, z: -2.54}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2063459124}
@@ -1075,7 +1075,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 170.06, y: 90.7}
+  m_SizeDelta: {x: 170.06, y: 29}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &254883062
 MonoBehaviour:
@@ -1085,25 +1085,20 @@ MonoBehaviour:
   m_GameObject: {fileID: 254883060}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: -405508275, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300000, guid: 0558b304e716630489cca13c71ceed7c, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
 --- !u!222 &254883063
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1297,9 +1292,9 @@ RectTransform:
   m_Father: {fileID: 254883061}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -175.83, y: 30.04004}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 28.98, y: 26.32}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &294112363
@@ -1366,15 +1361,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300002, guid: 0558b304e716630489cca13c71ceed7c, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -5160,9 +5155,9 @@ RectTransform:
   m_Father: {fileID: 254883061}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -112.17, y: 30.04004}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 30.79, y: 26.32}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1089907195
@@ -5229,15 +5224,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300006, guid: 0558b304e716630489cca13c71ceed7c, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -6345,7 +6340,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
+  m_BlockingObjects: 2
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
@@ -6360,7 +6355,7 @@ MonoBehaviour:
   m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 800, y: 600}
@@ -7937,9 +7932,9 @@ RectTransform:
   m_Father: {fileID: 254883061}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -144.47, y: 30.04004}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 33.73, y: 26.32}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1687656212
@@ -8006,15 +8001,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300004, guid: 0558b304e716630489cca13c71ceed7c, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -9514,9 +9509,9 @@ RectTransform:
   m_Father: {fileID: 254883061}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -78.38, y: 30.04004}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 35.84, y: 26.32}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2004061272
@@ -9583,15 +9578,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300008, guid: 0558b304e716630489cca13c71ceed7c, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -9893,9 +9888,9 @@ RectTransform:
   m_Father: {fileID: 254883061}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -208.48, y: 30.04}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 36.23, y: 26.32}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2063459125
@@ -9962,15 +9957,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300000, guid: 0558b304e716630489cca13c71ceed7c, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4

--- a/Assets/Scenes/etc.meta
+++ b/Assets/Scenes/etc.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 72ea407943dccad49bdcb3ff5064b3ea
+folderAsset: yes
+timeCreated: 1509329866
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MouseInput.cs
+++ b/Assets/Scripts/MouseInput.cs
@@ -2,63 +2,71 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
-
+using UnityEngine.EventSystems;
 
 [System.Serializable]
-public class MouseEvent: UnityEvent<int, Vector3, Transform>{
+public class MouseEvent : UnityEvent<int, Vector3, Transform>
+{
 }
 [System.Serializable]
-public class MouseUpEvent: UnityEvent<int>{
+public class MouseUpEvent : UnityEvent<int>
+{
 }
 
-public class MouseInput : MonoBehaviour {
-	public MouseEvent mouseButton;    // fires if a mouse button is held down this frame.
-	public MouseEvent mouseButtonDown;// fires if the user pressed a mouse button this frame.
-	public MouseUpEvent mouseButtonUp;  // fires if the user released a mouse button this frame.
+public class MouseInput : MonoBehaviour
+{
+    public MouseEvent mouseButton;    // fires if a mouse button is held down this frame.
+    public MouseEvent mouseButtonDown;// fires if the user pressed a mouse button this frame.
+    public MouseUpEvent mouseButtonUp;  // fires if the user released a mouse button this frame.
 
-	public MenuController menuController;
+    public MenuController menuController;
 
-	void Start () {
-		menuController = GetComponent<MenuController>();
-	}
-	void Update () {
-		for (int i = 0; i < 2; i++) {
-            if (menuController.menuOpen) continue;
-            // FIXME write a better solution to preventing moving when clicking on menu buttons.
-			if (i == 0 && menuController.popupMenuOpen) continue;
+    void Start()
+    {
+        menuController = GetComponent<MenuController>();
+    }
+    void Update()
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            if (i == 0 && menuController.popupMenuOpen) continue;
 
-			if (Input.GetMouseButton(i) || (Input.touchCount > 0 && Input.GetTouch(0).phase == TouchPhase.Began && i == 0)) {
-				RaycastHit hit;
-				if (RaycastFromMouse(out hit)) {
-					if (Input.GetMouseButtonDown(i)) {
-						mouseButtonDown.Invoke(i, new Vector3(hit.point.x, 0, hit.point.z), hit.transform);
-					}
-					mouseButton.Invoke(i, new Vector3(hit.point.x, 0, hit.point.z), hit.transform);
-				}
-			}
-			else if (Input.GetMouseButtonUp(i)) {
-				mouseButtonUp.Invoke(i);
-			}
-		}
-	}
+            //Dont do anything if clicking on a UI element
+            if (EventSystem.current.IsPointerOverGameObject()) continue;
 
-	bool RaycastFromMouse (out RaycastHit rcHit) {
-		RaycastHit hit;
+            if (Input.GetMouseButton(i) || (Input.touchCount > 0 && Input.GetTouch(0).phase == TouchPhase.Began && i == 0))
+            {
+                RaycastHit hit;
+                if (RaycastFromMouse(out hit))
+                {
+                    if (Input.GetMouseButtonDown(i))
+                    {
+                        mouseButtonDown.Invoke(i, new Vector3(hit.point.x, 0, hit.point.z), hit.transform);
+                    }
+                    mouseButton.Invoke(i, new Vector3(hit.point.x, 0, hit.point.z), hit.transform);
+                }
+            }
+            else if (Input.GetMouseButtonUp(i))
+            {
+                mouseButtonUp.Invoke(i);
+            }
+        }
+    }
 
-		Ray ray;
-		//for unity editor
-		#if UNITY_EDITOR
-		ray = Camera.main.ScreenPointToRay(Input.mousePosition);
-		//for touch device
-		#elif (UNITY_ANDROID || UNITY_IPHONE || UNITY_WP8)
-		ray = Camera.main.ScreenPointToRay(Input.GetTouch(0).position);
-		#endif
+    bool RaycastFromMouse(out RaycastHit rcHit)
+    {
+        RaycastHit hit;
 
-		if (Physics.Raycast(ray, out hit, 100.0f)) {
-			rcHit = hit;
-			return true;
-		}
-		rcHit = hit;
-		return false;
-	}
+        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+        
+
+        if (Physics.Raycast(ray, out hit, 100.0f))
+        {
+            rcHit = hit;
+            return true;
+        }
+
+        rcHit = hit;
+        return false;
+    }
 }

--- a/Assets/Scripts/PlayerShooting.cs
+++ b/Assets/Scripts/PlayerShooting.cs
@@ -20,10 +20,14 @@ public class PlayerShooting : MonoBehaviour
         weaponLine = GetComponent<LineRenderer>();
         weaponAudio = GetComponent<AudioSource>();
     }
-
-    void Update()
+    private void Start()
     {
-        if (Input.GetKeyDown(KeyCode.Mouse0) && Time.time > nextFire)
+        GameObject.Find("Input").GetComponent<MouseInput>().mouseButtonDown.AddListener(OnMouseButtonDown);
+
+    }
+    public void OnMouseButtonDown(int button, Vector3 pos, Transform obj)
+    {
+        if (button == 0 && Time.time > nextFire)
         {
             nextFire = Time.time + fireRate;
             StartCoroutine(Shoot(transform.forward));

--- a/Assets/Scripts/TapToMove.cs
+++ b/Assets/Scripts/TapToMove.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using UnityEngine.AI;
 
 public class TapToMove : MonoBehaviour
@@ -25,6 +26,11 @@ public class TapToMove : MonoBehaviour
         //save the y axis value of gameobject
         yAxis = gameObject.transform.position.y;
         agent = GetComponent<NavMeshAgent>();
+        ReadUpgradeInfo();
+    }
+
+    private void ReadUpgradeInfo()
+    {
         if (GameObject.Find("SHOP_ITEM_CARRYOVER"))
         {
             //speed +.5/level
@@ -40,7 +46,8 @@ public class TapToMove : MonoBehaviour
             Debug.LogWarning("SHOP_ITEM_CARRYOVER not present in scene, most likely game was not launched from shop scene. " +
                 "\nUsing default speed");
     }
-        void FixedUpdate()
+
+    void FixedUpdate()
     {
         Turn();
     }

--- a/Assets/Scripts/UI/UIRaycastBlock.cs
+++ b/Assets/Scripts/UI/UIRaycastBlock.cs
@@ -1,0 +1,10 @@
+﻿using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class UIRaycastBlock : MonoBehaviour, IPointerDownHandler
+{
+    public void OnPointerDown(PointerEventData eventData)
+    {
+        Debug.Log("Click detected on " + this.gameObject.name);
+    }
+}

--- a/Assets/Scripts/UI/UIRaycastBlock.cs.meta
+++ b/Assets/Scripts/UI/UIRaycastBlock.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: cc7c96a5a2617ae4ebec1607118872a8
+timeCreated: 1514831847
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI/Hot keys.png.meta
+++ b/Assets/UI/Hot keys.png.meta
@@ -1,9 +1,14 @@
 fileFormatVersion: 2
 guid: 0558b304e716630489cca13c71ceed7c
-timeCreated: 1508893302
+timeCreated: 1514833523
 licenseType: Free
 TextureImporter:
-  fileIDToRecycleName: {}
+  fileIDToRecycleName:
+    21300000: Hotkey_Inventory
+    21300002: Hotkey_Map
+    21300004: Hotkey_Journal
+    21300006: Hotkey_Enemies
+    21300008: Hotkey_Charecter
   externalObjects: {}
   serializedVersion: 4
   mipmaps:
@@ -40,12 +45,12 @@ TextureImporter:
   nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 1
+  spriteMode: 2
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteBorder: {x: 0, y: 1038, z: 0, w: 0}
   spritePixelsToUnits: 100
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -65,6 +70,7 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    androidETC2FallbackOverride: 0
   - buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -74,9 +80,100 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    androidETC2FallbackOverride: 0
+  - buildTarget: iPhone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  - buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
   spriteSheet:
     serializedVersion: 2
-    sprites: []
+    sprites:
+    - serializedVersion: 2
+      name: Hotkey_Inventory
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 1063
+        width: 604
+        height: 450
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+    - serializedVersion: 2
+      name: Hotkey_Map
+      rect:
+        serializedVersion: 2
+        x: 655
+        y: 1063
+        width: 401
+        height: 450
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+    - serializedVersion: 2
+      name: Hotkey_Journal
+      rect:
+        serializedVersion: 2
+        x: 1087
+        y: 1063
+        width: 548
+        height: 450
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+    - serializedVersion: 2
+      name: Hotkey_Enemies
+      rect:
+        serializedVersion: 2
+        x: 1693
+        y: 1063
+        width: 450
+        height: 450
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+    - serializedVersion: 2
+      name: Hotkey_Charecter
+      rect:
+        serializedVersion: 2
+        x: 2176
+        y: 1063
+        width: 568
+        height: 450
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
     outline: []
     physicsShape: []
   spritePackingTag: 


### PR DESCRIPTION
Modified mouseinput to not fire raycasts if the pointer is over UI elements. 
changed shooting to fire on mouse event from mouseinput instead of doing its own checks.